### PR TITLE
Fix broken install by updating mimemagic to 0.3.10

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -411,7 +411,9 @@ GEM
     mime-types (3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2016.0521)
-    mimemagic (0.3.5)
+    mimemagic (0.3.10)
+        nokogiri (~> 1)
+        rake
     mini_magick (4.9.5)
     mini_mime (1.0.2)
     mini_portile2 (2.4.0)


### PR DESCRIPTION
Mime Magic 0.3.5 has been [yanked](https://github.com/rails/rails/issues/41757#issue-840717572) from the gem library, giving a missing dependency error when installing huginn due to the reliance on version 0.3.5. One solution is to use a mimemagic library that is more current, but this leads to additional issues due to dependencies with nokogiri. One solution is to add the above code, which resolves the dependencies and the additional issues with nokogiri. 

Hat tip [@y-okamoto-1113](https://github.com/mimemagicrb/mimemagic/issues/98#issuecomment-807928425) for the solution.